### PR TITLE
filter for inet4 before awking

### DIFF
--- a/bin/local-ip-address
+++ b/bin/local-ip-address
@@ -11,9 +11,8 @@ if [[ "$(uname -s)" = "Linux"  ]]; then
 fi
 
 if [[ "$(uname -s)" = "Darwin" ]]; then
-  active_interface=$(netstat -nr | awk '{ if ($1 ~/default/) { print $6} }')
+  active_interface=$(netstat -nr -f inet|awk '/default/ && !/bridge/ { print $6 }')
 
-  ifconfig ${active_interface} | \
-    grep -v inet6 | \
-    awk '{ if ($1 ~/inet/) { print $2} }'
+  ifconfig ${active_interface} inet | \
+    awk '/inet/ { print $2 }'
 fi


### PR DESCRIPTION
I found that since I had bridges defined with a default route that this command didn't work for me.   plus the grep call was just bugging me since it's unnecessary when you call ifconfig with 'inet' as the address family. 