### PR TITLE
add a missing `git` to gitlgg alias

### DIFF
--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -91,7 +91,7 @@ alias gitadd='git add'
 alias gitci='git ci -v'
 alias gitdiff='git diff'
 alias gitignored='git ls-files --others --i --exclude-standard'
-alias gitlgg="log --pretty=format:'%Cred%h%Creset -%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'"
+alias gitlgg="git log --pretty=format:'%Cred%h%Creset -%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'"
 alias gitlog='git log'
 alias gitloll='git log --graph --decorate --pretty=oneline --abbrev-commit'
 alias gitmerge='git merge'


### PR DESCRIPTION
# Motivation and Context

I believe that gitlgg should alias something like `git log`and not just `log`

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Adding utility script(s)
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates


