### PR TITLE
Fix dumb typo in newscript

### DIFF
--- a/bin/newscript
+++ b/bin/newscript
@@ -78,7 +78,9 @@ def parseCLI():
                       help='Debug setting',
                       action='store_true')
   parser.add_argument('-l', '--log-level',
-                      help='Log level -set to DEBUG, INFO, ERROR, WARNING or CRITICAL',
+                      type=str.upper,
+                      help='set log level',
+                      choices=['DEBUG','INFO','ERROR','WARNING','CRITICAL'],
                       default='INFO')
 
   cliArgs = parser.parse_args()

--- a/bin/newscript
+++ b/bin/newscript
@@ -90,7 +90,7 @@ def parseCLI():
   return cliArgs
 
 
-def main:
+def main():
   '''
   Main program driver
   '''
@@ -98,7 +98,7 @@ def main:
 
 
 if __name__ == '__main__':
-  main
+  main()
 
 END_PYTHON_SCRIPT
   write_script(name: name, source: rawScript)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context

Fix 

# Description

Fix typo in `def main` in python template

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Adding utility script(s)
- [ ] Add/update function in `jpb.pluginn.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General
- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts
- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable. 
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
