### PR TITLE
Fix ohmyzsh link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 # jpb.zshplugin
 
-This is a ZSH plugin usable with [Zgen](https://github.com/tarjoilija/zgen) and other [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)-compatible frameworks to easily load some of my tool scripts.
+This is a ZSH plugin usable with [Zgen](https://github.com/tarjoilija/zgen) and other [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)-compatible frameworks to easily load some of my tool scripts.
 
 This contains miscellaneous tool scripts and aliases that are not specific enough for one of my more targeted ZSH plugins.
 
@@ -36,7 +36,7 @@ add `zgen load unixorn/jpb.zshplugin` to your .zshrc with your other load comman
 1. git clone this repository, then add its bin directory to your `$PATH`.
 2. Add `source /path/to/here/jpb.plugin.zsh` to your `.zshrc` file.
 
-The scripts in this collection don't actually require you to be using ZSH as your login shell, they're being distributed as an [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)-compatible plugin because it's convenient for me.
+The scripts in this collection don't actually require you to be using ZSH as your login shell, they're being distributed as an [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)-compatible plugin because it's convenient for me.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
+## Table of Contents
 
 - [jpb.zshplugin](#jpbzshplugin)
   - [Status](#status)
   - [Installing](#installing)
     - [Antigen](#antigen)
-    - [Zgen](#zgen)
-    - [Without using any frameworks](#without-using-any-frameworks)
+    - [Zgen/Zgenom](#zgenzgenom)
+    - [Without using a framework](#without-using-a-framework)
   - [Credits](#credits)
   - [Other useful ZSH plugins](#other-useful-zsh-plugins)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 # jpb.zshplugin
 
-This is a ZSH plugin usable with [Zgen](https://github.com/tarjoilija/zgen) and other [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)-compatible frameworks to easily load some of my tool scripts.
+This is a ZSH plugin usable with [zgenom](https://github.com/jandamm/zgenom) and other [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)-compatible frameworks to easily load some of my tool scripts.
 
 This contains miscellaneous tool scripts and aliases that are not specific enough for one of my more targeted ZSH plugins.
 
@@ -25,11 +25,11 @@ This contains miscellaneous tool scripts and aliases that are not specific enoug
 
 ### Antigen
 
-add `antigen bundle unixorn/jpb.zshplugin` to your .zshrc
+add `antigen bundle unixorn/jpb.zshplugin` to your `.zshrc`
 
-### Zgen
+### Zgen/Zgenom
 
-add `zgen load unixorn/jpb.zshplugin` to your .zshrc with your other load commands.
+add `zgen load unixorn/jpb.zshplugin` to your `.zshrc` with your other load commands.
 
 ### Without using a framework
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

* Update oh-my-zsh links to point to new location on Github.
* Update zgen references to zgenom since zgenom is getting actively maintained.

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [x] Test updates

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General
- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts
- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
