### PR TITLE
Add debug() to bash scripts created by newscript

### DIFF
--- a/bin/newscript
+++ b/bin/newscript
@@ -18,18 +18,18 @@
 # Got tired of 'vim foo' && chmod +x foo && cat /path/to/template > foo,
 # so made a helper to create new scripts with the base stuff I wanted in them.
 
-require 'rubygems'
-require 'pp'
-require 'optimist'
+require "rubygems"
+require "pp"
+require "optimist"
 
 def clean_name(name)
   # get rid of toxic spaces
-  return name.gsub(' ', '_')
+  return name.gsub(" ", "_")
 end
 
 def write_script(name:, source:)
-  if File.exist?(name) then
-    puts "There's already something named #{name} here. Bailing out."
+  if File.exist?(name)
+    puts "There's already a file at #{name}. Bailing out."
     exit 13
   else
     File.open(name, "w") do |content|
@@ -209,11 +209,11 @@ def main
   where [options] are:
   EOS
 
-    opt :debug, "Set debug level", :default => 0
-    opt :script_type, "Script type. Valid options: bash, python or ruby", :type => String, :default => 'bash'
+    opt :debug, "Set debug level", default: 0
+    opt :script_type, "Script type. Valid options: bash, python or ruby", type: String, default: "bash"
   end
 
-  validFlavors = ['bash', 'python', 'ruby']
+  validFlavors = ["bash", "python", "ruby"]
 
   # Sanity check args
   Optimist::die :script_type, "#{$opts[:script_type]} must be in #{validFlavors}" unless validFlavors.include?($opts[:script_type])
@@ -221,11 +221,11 @@ def main
 
   ARGV.each { |name|
     case $opts[:script_type]
-    when 'bash'
+    when "bash"
       generate_bash_script(name: name)
-    when 'python'
+    when "python"
       generate_python_script(name: name)
-    when 'ruby'
+    when "ruby"
       generate_ruby_script(name: name)
     else
       puts "script type #{$opts[:script_type]} unknown"

--- a/bin/newscript
+++ b/bin/newscript
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-#   Copyright 2016-2020 Joe Block <jpb@unixorn.net>
+#   Copyright 2016-2021 Joe Block <jpb@unixorn.net>
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -53,7 +53,19 @@ if [[ -n "$DEBUG" ]]; then
   set -x
 fi
 
-fail() {
+function cleanup() {
+  if [[ -d "$SCRATCH_D" ]]; then
+    rm -fr "$SCRATCH_D"
+  fi
+}
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
   printf '%s\\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
   exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
 }
@@ -65,12 +77,6 @@ if [[ ! "$SCRATCH_D" || ! -d "$SCRATCH_D" ]]; then
   echo "Could not create temp dir"
   exit 1
 fi
-
-cleanup() {
-  if [[ -d "$SCRATCH_D" ]]; then
-    rm -fr "$SCRATCH_D"
-  fi
-}
 
 trap cleanup EXIT
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context

I end up adding a debug function to most bash scripts anyway, so add it to the template.

# Description

- Add `debug()` function to bash template in `newscript`
- rubocop cleanups in `newscript`

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
