### PR TITLE
Move trapint handling to zsh quickstart kit

### DIFF
--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -300,15 +300,6 @@ alias -s pdf=open
 alias edit="$EDITOR"' $(eval ${$(fc -l -1)[2,-1]} -l)'
 alias knife='nocorrect knife'
 
-# from: https://vinipsmaker.wordpress.com/2014/02/23/my-zsh-config/
-# bash prints ^C when you're typing a command and control-c to cancel, so it
-# is easy to see it wasn't executed. By default, zsh doesn't print the ^C.
-# Fortunately, it is easy to trap SIGINT.
-TRAPINT() {
-  print -n -u2 '^C'
-  return $((128+$1))
-}
-
 function hexpass() {
   openssl rand -hex 24 $@
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Description

TRAPINT handling is borged by zsh-quickstart-kit in https://github.com/unixorn/zsh-quickstart-kit/pull/117

Merge this after that.


# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Adding or updating utility script(s)
- [x] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
