### PR TITLE
Make it easier to remove the scratchdir helpers in newscript

### DIFF
--- a/bin/newscript
+++ b/bin/newscript
@@ -53,12 +53,6 @@ if [[ -n "$DEBUG" ]]; then
   set -x
 fi
 
-function cleanup() {
-  if [[ -d "$SCRATCH_D" ]]; then
-    rm -fr "$SCRATCH_D"
-  fi
-}
-
 function debug() {
   if [[ -n "$DEBUG" ]]; then
     echo "$@"
@@ -75,13 +69,19 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
+function cleanup() {
+  if [[ -d "$SCRATCH_D" ]]; then
+    rm -fr "$SCRATCH_D"
+  fi  
+}  
+
 # Set up a working scratch directory
 SCRATCH_D=$(mktemp -d)
 
 if [[ ! "$SCRATCH_D" || ! -d "$SCRATCH_D" ]]; then
   echo "Could not create temp dir"
   exit 1
-fi
+fi  
 
 trap cleanup EXIT
 


### PR DESCRIPTION
# Motivation and Context

We don't always need scratch directories in new scripts.

# Description

Keep the scratchdir functions together so they're easier to remove when not needed by a new script.

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
