### PR TITLE
Add human-time helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `http_debug` | | Dump debug info for an url |
 | `http_headers` | | Dump http headers for an url |
 | `html2markdown` | [https://github.com/realpython/python-scripts/](https://github.com/realpython/python-scripts/blob/master/scripts/14_html_to_markdown.sh) | Convert all html files in a single directory to markdown |
+| `human-time` | | Converts integer seconds into human-understandable time. `human-time 88000` will print `1d 26m 40s` |
 | `iflip` | [twirrim/iflip](https://github.com/twirrim/iflip/blob/master/iflip) | Tableflips a text string |
 | `ipaddresses` | Mine | Dumps all the ip addresses for the host |
 | `json2yaml` | ? | Converts JSON to YAML |

--- a/bin/human-time
+++ b/bin/human-time
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Turns integer seconds into human-understandable time.
+#
+# $ human-time 88000 
+# 1d 26m 40s
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2.0
+
+# shellcheck disable=SC2004
+human_time() {
+    local raw_seconds=$1
+    local days=$(( raw_seconds / 60 / 60 / 24 ))
+    local hours=$(( raw_seconds / 60 / 60 % 24 ))
+    local minutes=$(( raw_seconds / 60 % 60 ))
+    local seconds=$(( raw_seconds % 60 ))
+    (( $days > 0 )) && echo -n "${days}d "
+    (( $hours > 0 )) && echo -n "${hours}h "
+    (( $minutes > 0 )) && echo -n "${minutes}m "
+    echo "${seconds}s "
+}
+
+human_time "$@"


### PR DESCRIPTION
# Description

`human-time` converts integer numbers of seconds into more human-intuitive form.

`human-time 88000` will print `1d 26m 40s`, for example.

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated Readme.md to give credit to the script author
- [x] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
