### PR TITLE
Add a jira helper script

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -50,5 +50,6 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_NATURAL_LANGUAGE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `$` | Jordan Sissel's [dotfiles](https://github.com/jordansissel/dotfiles/blob/master/.zshrc) | A shim so that when you're pasting a command example with a leading `$` it will just work. |
 |  `ansi2html` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Convert terminal color ANSI escape sequences to HTML. |
 | `change-extension` | ? | Changes file extentions |
-| `clean-clipboard` | Mine | Cleans the macOs clipboard |
+| `clean-clipboard` | Mine | Cleans the macOS clipboard |
 | `clean-whiteboard-picture` | [https://gist.github.com/lelandbatey/8677901](https://gist.github.com/lelandbatey/8677901) | Cleans up pictures of whiteboards and pumps up contrast |
 | `dedupe-in-order` | `awk` oneliner |
 | `diff-summary` | Gary Bernhardt's [dotfiles](https://github.com/garybernhardt/dotfiles/blob/main/bin/gn) |Prints a summary of piped diff files or `git diff` output |
@@ -56,13 +56,13 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `get-site-cert` | ? | Download the SSL cert from a site |
 | `gxpr` | [brutasse's dotfiles](https://github.com/brutasse/dotfiles/blob/master/bin/gxpr). | Uses Google and or Wolfram Alpha to evaluate expressions. Requires `URI::Escape` to be installed with `cpan`. |
 | `headers` | Zach Holman's [dotfiles](https://github.com/holman/dotfiles/blob/master/bin/headers) | Gets the HTTP headers from a server |
-| `http_debug` | | Dump debug info for an url |
-| `http_headers` | | Dump http headers for an url |
-| `html2markdown` | [https://github.com/realpython/python-scripts/](https://github.com/realpython/python-scripts/blob/master/scripts/14_html_to_markdown.sh) | Convert all html files in a single directory to markdown |
+| `http_debug` | | Dump debug info for a URL |
+| `http_headers` | | Dump http headers for a URL |
+| `html2markdown` | [https://github.com/realpython/python-scripts/](https://github.com/realpython/python-scripts/blob/master/scripts/14_html_to_markdown.sh) | Convert all HTML files in a single directory to Markdown |
 | `human-time` | | Converts integer seconds into human-understandable time. `human-time 88000` will print `1d 26m 40s` |
 | `iflip` | [twirrim/iflip](https://github.com/twirrim/iflip/blob/master/iflip) | Tableflips a text string |
 | `ipaddresses` | Mine | Dumps all the ip addresses for the host |
-| `jira` | Mine | Opens a jira ticket from the command line |
+| `jira` | Mine | Opens a jira ticket from the command-line |
 | `jmemstat` | [majk1's shellrc](https://github.com/majk1/shellrc/blob/master/utils/jmemstat.sh) | Displays a memory information summary for a java process |
 | `json2yaml` | ? | Converts JSON to YAML |
 | `jsondiff` | ? | Diff JSON files and cope with key-order differences by processing with json.tool |
@@ -71,7 +71,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `lsof-unlinked` | [https://github.com/ludios/ubuntils/](https://github.com/ludios/ubuntils/blob/master/bin/)lsof-unlinked | List all open files (but not mapped files) that have been unlinked. |
 | `memcached-tool` | Brad Fitzpatrick <brad@danga.com> | stats/management tool for memcached |
 | `memcached-top` | [http://code.google.com/p/memcache-top/](http://code.google.com/p/memcache-top/) | Dumps basic `memcached` stats similarly to `top` |
-| `mtr-url` | ? | Parses hostname from an URL, then does a `mtr` to it. |
+| `mtr-url` | ? | Parses hostname from a URL, then does a `mtr` to it. |
 | `murder` | [Anonymous Gist](https://gist.github.com/anonymous/32b1e619bc9e7fbe0eaa#!/bin/bash) | Takes a list of PIDs and ends the processes through increasingly rude means. |
 | `name-window` | Mine | Names a terminal window/tab by sending escape codes. |
 | `newscript` | Mine | Creates a new script from a template and does `chmod 755` on it. |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `human-time` | | Converts integer seconds into human-understandable time. `human-time 88000` will print `1d 26m 40s` |
 | `iflip` | [twirrim/iflip](https://github.com/twirrim/iflip/blob/master/iflip) | Tableflips a text string |
 | `ipaddresses` | Mine | Dumps all the ip addresses for the host |
+| `jira` | Mine | Opens a jira ticket from the command line |
 | `jmemstat` | [majk1's shellrc](https://github.com/majk1/shellrc/blob/master/utils/jmemstat.sh) | Displays a memory information summary for a java process |
 | `json2yaml` | ? | Converts JSON to YAML |
 | `jsondiff` | ? | Diff JSON files and cope with key-order differences by processing with json.tool |

--- a/bin/jira
+++ b/bin/jira
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Open a jira ticket from the command line
+#
+# Copyright 2022, Joe Block <jpb@unixorn.net>
+
+SETTINGS_F="${HOME}/.jpbscripts/jira-settings.sh"
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  fail "This script only works on macOS, sorry."
+fi
+
+if [[ $# != 1 ]]; then
+  fail "You must specify a JIRA ticket"
+fi
+
+if [[ -z "${JIRA_URL}" ]]; then
+  if [[ ! -r "${SETTINGS_F}" ]]; then
+    fail "You need to either set JIRA_URL in your environment or create ${SETTINGS_F} containing a line like 'JIRA_URL=http://your.jira.server'"
+  fi
+
+  # shellcheck disable=SC1090
+  source "${SETTINGS_F}"
+fi
+debug "JIRA_URL: ${JIRA_URL}"
+
+if [[ -z "${JIRA_URL}" ]]; then
+  fail "JIRA_URL is not set in your environment. Create ${SETTINGS_F} with 'JIRA_URL=http://your.jira.server' in it"
+fi
+
+open "$JIRA_URL/browse/$1"


### PR DESCRIPTION


# Motivation and Context

Make it easy to open an existing jira ticket from the command line.

# Description

Add `jira` helper script

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated Readme.md to give credit to the script author
- [x] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
