### PR TITLE
Update `newscript`

### DIFF
--- a/bin/newscript
+++ b/bin/newscript
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-#   Copyright 2016-2021 Joe Block <jpb@unixorn.net>
+#   Copyright 2016-2022 Joe Block <jpb@unixorn.net>
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -72,8 +72,8 @@ function has() {
 function cleanup() {
   if [[ -d "$SCRATCH_D" ]]; then
     rm -fr "$SCRATCH_D"
-  fi  
-}  
+  fi
+}
 
 # Set up a working scratch directory
 SCRATCH_D=$(mktemp -d)
@@ -81,7 +81,7 @@ SCRATCH_D=$(mktemp -d)
 if [[ ! "$SCRATCH_D" || ! -d "$SCRATCH_D" ]]; then
   echo "Could not create temp dir"
   exit 1
-fi  
+fi
 
 trap cleanup EXIT
 
@@ -105,36 +105,36 @@ import sys
 
 
 def parseCLI():
-  '''
-  Parse the command line options
-  '''
-  parser = argparse.ArgumentParser()
-  parser.add_argument('-d', '--debug',
-                      help='Debug setting',
-                      action='store_true')
-  parser.add_argument('-l', '--log-level',
-                      type=str.upper,
-                      help='set log level',
-                      choices=['DEBUG','INFO','ERROR','WARNING','CRITICAL'],
-                      default='INFO')
+    '''
+    Parse the command line options
+    '''
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--debug',
+                        help='Debug setting',
+                        action='store_true')
+    parser.add_argument('-l', '--log-level',
+                        type=str.upper,
+                        help='set log level',
+                        choices=['DEBUG','INFO','ERROR','WARNING','CRITICAL'],
+                        default='INFO')
 
-  cliArgs = parser.parse_args()
-  loglevel = getattr(logging, cliArgs.log_level.upper(), None)
-  logFormat = "[%(asctime)s][%(levelname)8s][%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
-  logging.basicConfig(level=loglevel, format=logFormat)
-  logging.info('Set log level to %s', cliArgs.log_level.upper())
-  return cliArgs
+    cli = parser.parse_args()
+    loglevel = getattr(logging, cli.log_level.upper(), None)
+    logFormat = "[%(asctime)s][%(levelname)8s][%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
+    logging.basicConfig(level=loglevel, format=logFormat)
+    logging.info('Set log level to %s', cli.log_level.upper())
+    return cli
 
 
 def main():
-  '''
-  Main program driver
-  '''
-  cliArgs = parseCLI()
+    '''
+    Main program driver
+    '''
+    cli = parseCLI()
 
 
 if __name__ == '__main__':
-  main()
+    main()
 
 END_PYTHON_SCRIPT
   write_script(name: name, source: rawScript)

--- a/bin/newscript
+++ b/bin/newscript
@@ -69,10 +69,29 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
-function cleanup() {
-  if [[ -d "$SCRATCH_D" ]]; then
-    rm -fr "$SCRATCH_D"
-  fi
+# on_exit and add_on_exit from http://www.linuxjournal.com/content/use-bash-trap-statement-cleanup-temporary-files
+
+# Usage:
+#   add_on_exit rm -f /tmp/foo
+#   add_on_exit echo "I am exiting"
+#   tempfile=$(mktemp)
+#   add_on_exit rm -f "$tempfile"
+
+function on_exit()
+{
+    for i in "${on_exit_items[@]}"
+    do
+        eval $i
+    done
+}
+
+function add_on_exit()
+{
+    local n=${#on_exit_items[*]}
+    on_exit_items[$n]="$*"
+    if [[ $n -eq 0 ]]; then
+        trap on_exit EXIT
+    fi
 }
 
 # Set up a working scratch directory
@@ -83,7 +102,7 @@ if [[ ! "$SCRATCH_D" || ! -d "$SCRATCH_D" ]]; then
   exit 1
 fi
 
-trap cleanup EXIT
+add_on_exit rm -rf "$SCRATCH_D"
 
 END_BASH_SCRIPT
   write_script(name: name, source: rawScript)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context

Improve scripts generated by `newscript`


# Description

Use better exit handling into bash scripts generated by `newscript`.

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
