### PR TITLE
Add `lineprof`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `jmemstat` | [majk1's shellrc](https://github.com/majk1/shellrc/blob/master/utils/jmemstat.sh) | Displays a memory information summary for a java process |
 | `json2yaml` | ? | Converts JSON to YAML |
 | `jsondiff` | ? | Diff JSON files and cope with key-order differences by processing with json.tool |
+| `lineprof` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles)  | Annotates each line of input with the number of milliseconds elapsed since the last line. Useful for figuring out slow points of output-producing programs. |
 | `local-ip-address` | jpb@unixorn.net | Print local IP v4 address |
 | `local-ipv6-address` | jpb@unixorn.net | Print local IP v6 address |
 | `lsof-unlinked` | [ludios/ubuntils/](https://github.com/ludios/ubuntils/blob/master/bin/lsof-unlinked) | List all open files (but not mapped files) that have been unlinked. |

--- a/bin/lineprof
+++ b/bin/lineprof
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby --disable-gems -n
+#
+# Annotates each line of input with the number of milliseconds elapsed since
+# the last line. Useful for figuring out slow points of output-producing programs.
+# Source: https://github.com/mislav/dotfiles/blob/master/bin/lineprof
+Annotates each line of input with the number of milliseconds elapsed since the last line. Useful for figuring out slow points of output-producing programs. Source: https://github.com/mislav/dotfiles/blob/master/bin/lineprof
+
+BEGIN {
+  $last = $start = Time.now
+}
+
+now = Time.now
+delta = now - $last
+$last = now
+
+printf '%5.2f ', delta * 1000
+puts $_
+
+END {
+  delta = $last - $start
+  printf "%5.2f ms total\n", delta * 1000
+}


### PR DESCRIPTION
# Description

Add `lineprof`. Annotates each line of input with the number of milliseconds elapsed since the last line. Useful for figuring out slow points of output-producing programs.

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
