### PR TITLE
Add more `lsof` helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `lineprof` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles)  | Annotates each line of input with the number of milliseconds elapsed since the last line. Useful for figuring out slow points of output-producing programs. |
 | `local-ip-address` | jpb@unixorn.net | Print local IP v4 address |
 | `local-ipv6-address` | jpb@unixorn.net | Print local IP v6 address |
+| `ls-open-ports` | jpb@unixorn.net | List open ports |
+| `ls-sockets` | jpb@unixorn.net | List open sockets |
+| `ls-tcp-sockets` | jpb@unixorn.net | List open tcp sockets |
+| `ls-udp-sockets` | jpb@unixorn.net | List open udp sockets |
 | `lsof-unlinked` | [ludios/ubuntils/](https://github.com/ludios/ubuntils/blob/master/bin/lsof-unlinked) | List all open files (but not mapped files) that have been unlinked. |
 | `memcached-tool` | Brad Fitzpatrick <brad@danga.com> | stats/management tool for memcached |
 | `memcached-top` | [http://code.google.com/p/memcache-top/](http://code.google.com/p/memcache-top/) | Dumps basic `memcached` stats similarly to `top` |

--- a/bin/ls-open-ports
+++ b/bin/ls-open-ports
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# List open ports
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+function linux-listeners() {
+    # ss is the new hotness
+    if has ss; then
+        ss -lnptu
+    else
+        lsof -i -n -P | awk 'NR==1 || /LISTEN/'
+    fi
+}
+
+# Print the currently listening IP ports
+
+case $(uname) in
+  Linux)
+    linux-listeners
+    ;;
+  Darwin)
+    lsof -i -n -P | awk 'NR==1 || /LISTEN/'
+    ;;
+esac

--- a/bin/ls-sockets
+++ b/bin/ls-sockets
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# List open sockets
+
+exec sudo lsof -i -P

--- a/bin/ls-tcp-sockets
+++ b/bin/ls-tcp-sockets
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# List open TCP sockets
+
+sudo lsof -i -P | grep -i tcp

--- a/bin/ls-udp-sockets
+++ b/bin/ls-udp-sockets
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# List open UDP sockets
+
+sudo lsof -i -P | grep -i udp

--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -139,11 +139,11 @@ ff() { find . -type f -iname '*'$*'*' -ls ; }
 
 # Got tired of constantly doing history | grep X | tail
 hgrep40() {
-  history | grep -i "$@" | tail -40
+  history | grep -i $@ | tail -40
 }
 
 hgrep() {
-  history | grep -i "$@" | tail -20
+  history | grep -i $@ | tail -20
 }
 
 # Syntax-highlight JSON strings or files


### PR DESCRIPTION

# Motivation and Context

I can never remember the right args to `lsof`, so add some helper scripts.

# Description

- Add `ls-sockets`
- Add `ls-tcp-sockets`
- Add `ls-udp-sockets`

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated Readme.md to give credit to the script author
- [x] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
