### PR TITLE
Add `pbpaste` and `pbcopy` helpers on linux

### DIFF
--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -591,7 +591,29 @@ golistdeps(){
 
 # Linux-specific stuff
 if on_linux; then
+  # Add helper scripts with macOS tool names so I don't have to remember
+  # the names of the linux-specific ones.
   if exists xdg-open; then
     alias open='xdg-open'
+  fi
+
+  if exists xclip; then
+    function pbcopy {
+      if type xclip > /dev/null; then
+        xclip -selection clipboard
+      fi
+      if type xsel > /dev/null; then
+        xsel --clipboard --input
+      fi
+    }
+
+    function pbpaste {
+      if type xclip > /dev/null; then
+        xclip -selection clipboard -o
+      fi
+      if type xsel > /dev/null; then
+        xsel --clipboard --output
+      fi
+    }
   fi
 fi


### PR DESCRIPTION
# Motivation and Context

I don't want to have to remember the names or syntax of the linux equivalents for `pbpaste` and `pbcopy` when I'm in on a linux machine.

# Description

When running on linux, if there's an `xclip` command, add `pbpaste` and `pbcopy` helper scripts.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Adding or updating utility script(s)
- [x] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
