### PR TITLE
Add `dns-resolvers` script

### DIFF
--- a/bin/750
+++ b/bin/750
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+#
+exec chmod 750 $*

--- a/bin/dns-resolvers
+++ b/bin/dns-resolvers
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Show DNS resolver information. Of course macOS makes it more complicated
+# than `cat /etc/resolv.conf`
+#
+# Copyright 2023, Joe Block <jpb@unixorn.net>
+
+set -o pipefail
+
+case $(uname) in
+  Darwin)
+    scutil --dns | awk '/^(DNS|resolver|  (search|nameserver|domain))/'
+    ;;
+  Linux)
+    cat /etc/resolv.conf
+    ;;
+esac

--- a/bin/newscript
+++ b/bin/newscript
@@ -60,7 +60,7 @@ function debug() {
 }
 
 function echo-stderr() {
-  echo "$@" 1>&2
+  echo "$@" 1>&2  ## Send message to stderr.
 }
 
 function fail() {


### PR DESCRIPTION
# Motivation and Context

Naturally macOS makes figuring out what DNS servers your machine is using more complicated than `cat /etc/resolv.conf`.

I can never remember the right `scutil` command, so adding this helper script.

# Description

- Add `dns-resolvers` script

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [x] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
