### PR TITLE
Add `nanotime` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `mtr-url` | ? | Parses hostname from a URL, then does a `mtr` to it. |
 | `murder` | [Anonymous Gist](https://gist.github.com/anonymous/32b1e619bc9e7fbe0eaa#!/bin/bash) | Takes a list of PIDs and ends the processes through increasingly rude means. |
 | `name-window` | jpb@unixorn.net | Names a terminal window/tab by sending escape codes. |
+| `nanotime` | jpb@unixorn.net | Times a process and gives you results in milliseconds |
 | `newscript` | jpb@unixorn.net | Creates a new script from a template and does `chmod 755` on it. |
 | `pidpwd` | jpb@unixorn.net | Find the pwd of a given pid. Only works on linux since it requires `/proc` |
 | `pjson` | [https://coderwall.com/](https://coderwall.com/p/hwu5uq?i=9&p=1&q=sort%3Ascore+desc&t%5B%5D=zsh) | Prettify json files |

--- a/bin/clean-whiteboard-picture
+++ b/bin/clean-whiteboard-picture
@@ -12,7 +12,7 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
-if [[ ! has convert ]]; then
+if ! has convert; then
   fail "Can't find 'convert' in your PATH"
 fi
 

--- a/bin/nanotime
+++ b/bin/nanotime
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2023 Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -euo pipefail
+
+function fail() {
+  printf '%s\\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function nanotime() {
+  ts=$(date +%s%N)
+
+  "$@"
+
+  # shellcheck disable=SC2004
+  tt=$((($(date +%s%N) - $ts)/1000000))
+  echo "time $tt ms" >&2
+}
+
+if [[ "$(uname)" != "Linux" ]];then
+  fail "Date command only supports nanoseconds on Linux"
+fi
+
+nanotime "$@"

--- a/bin/time-in-ms
+++ b/bin/time-in-ms
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-ts=$(date +%s%N)
-
-$@
-
-tt=$((($(date +%s%N) - $ts)/1000000))
-
-echo "time $tt ms" >&2

--- a/bin/time-in-ms
+++ b/bin/time-in-ms
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+ts=$(date +%s%N)
+
+$@
+
+tt=$((($(date +%s%N) - $ts)/1000000))
+
+echo "time $tt ms" >&2

--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -597,6 +597,8 @@ if on_linux; then
     alias open='xdg-open'
   fi
 
+  alias time-in-ms=nanotime
+
   if exists xclip; then
     function pbcopy {
       if type xclip > /dev/null; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context

Sometimes I need very granular timing 

# Description

- Add `nanotime` command that reports execution time in milliseconds

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [x] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated Readme.md to give credit to the script author
- [x] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
