### PR TITLE
Add `boring-prompt()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `retry` | jpb@unixorn.net | Re-run a command until it exits successfully. Waits `$DELAY` seconds between attempts. |
 | `seq` | Dave Taylor's [blog](https://www.askdavetaylor.com/step_through_count_numeric_values_bash_shell_script/) | Generates integer values from low...high similar to `range` in better programming languages |
 | `snag-dl` | ? | Moves the most recent file in `~/Downloads` into the current directory |
-| `solo` | Timothy Kay's [solo](http://timkay.com/solo/) | Prevents a program from running more than one copy at a time. |
+| `solo` | Timothy Kay's `solo` script | Prevents a program from running more than one copy at a time. |
 | `steal` | jpb@unixorn.net | Helper for quickly resetting ownership of files you created with the wrong userid |
 | `strip-ansi-codes` | jpb@unixorn.net | Strips the ANSI codes from STDIN. Makes grepping through things like jenkins logs considerably less painful |
 | `tableflip` | [hangops](https://hangops.slack.com) slack | Prints a tableflip animation. |

--- a/bin/gtouch
+++ b/bin/gtouch
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# This base script is MIT licensed so you can base your
+# own work on it.
+#
+# touch a file and add it to git
+#
+# Copyright 2023, Joe Block <jpb@unixorn.net>
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  # shellcheck disable=SC2086
+  if [[ "$(echo $DEBUG | tr '[:upper:]' '[:lower:]')" == "verbose" ]]; then
+    set -x
+  fi
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function echo-stderr() {
+  echo "$@" 1>&2  ## Send message to stderr.
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+# on_exit and add_on_exit from http://www.linuxjournal.com/content/use-bash-trap-statement-cleanup-temporary-files
+
+# Usage:
+#   add_on_exit rm -f /tmp/foo
+#   add_on_exit echo "I am exiting"
+#   tempfile=$(mktemp)
+#   add_on_exit rm -f "$tempfile"
+
+function on_exit()
+{
+  for i in "${on_exit_items[@]}"
+  do
+    # shellcheck disable=SC2086
+    eval $i
+  done
+}
+
+function add_on_exit()
+{
+  local n=${#on_exit_items[*]}
+  # shellcheck disable=SC2004
+  on_exit_items[$n]="$*"
+  if [[ $n -eq 0 ]]; then
+    trap on_exit EXIT
+  fi
+}
+
+# Set up a working scratch directory
+SCRATCH_D=$(mktemp -d)
+
+if [[ ! "$SCRATCH_D" || ! -d "$SCRATCH_D" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+add_on_exit rm -rf "$SCRATCH_D"
+
+function my-name() {
+  basename "$0"
+}
+
+function usage() {
+  echo "Usage: $(my-name) ARG ARG"
+}
+
+if [[ $# < 1 ]];then

--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -38,8 +38,7 @@ function is-interactive() { [ -t 1 ] }
 function is-interactive-session() { [ -t 1 ] }
 
 # Add our plugin's bin diretory to user's path
-PLUGIN_BIN="$(dirname $0)/bin"
-export PATH="${PATH}:${PLUGIN_BIN}"
+path+=("${0:h}/bin")
 
 if [[ "$(uname -s)" = 'Linux'  ]]; then
   # We're on linux

--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -655,3 +655,6 @@ ssh-copy-key() {
 	cat ${HOME}/.ssh/id_rsa.pub | ssh "$destination" "mkdir -p ~/.ssh; cat >> ~/.ssh/authorized_keys"
 }
 
+boring-prompt() {
+  PROMPT_COMMAND='' PS0='' PS1='$ ' zsh
+}


### PR DESCRIPTION
# Description

- Add a quick way to make the prompt boring for screen shots
- Use more idiomatic `zsh` for updating the user's `$PATH`

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Adding or updating utility script(s)
- [x] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
