### PR TITLE
Add `ssh-remove-known-host` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `seq` | Dave Taylor's [blog](https://www.askdavetaylor.com/step_through_count_numeric_values_bash_shell_script/) | Generates integer values from low...high similar to `range` in better programming languages |
 | `snag-dl` | ? | Moves the most recent file in `~/Downloads` into the current directory |
 | `solo` | Timothy Kay's `solo` script | Prevents a program from running more than one copy at a time. |
+| `ssh-remove-known-host` | jpb@unixorn.net | Helper script to remove a known hosts entry. I can never remember the command for removing a known_hosts entry, and the new format makes it more pain in the ass than just editing and searching for the ip/hostname. |
 | `steal` | jpb@unixorn.net | Helper for quickly resetting ownership of files you created with the wrong userid |
 | `strip-ansi-codes` | jpb@unixorn.net | Strips the ANSI codes from STDIN. Makes grepping through things like jenkins logs considerably less painful |
 | `tableflip` | [hangops](https://hangops.slack.com) slack | Prints a tableflip animation. |

--- a/bin/newscript
+++ b/bin/newscript
@@ -122,6 +122,8 @@ function get-settings() {
 
 function check-dependencies() {
   debug "Checking dependencies..."
+  # shellcheck disable=SC2041
+  # Placeholders for whatever programs you really need
   for p in 'bash' 'cat'
   do
     if ! has $p; then

--- a/bin/ssh-remove-known-host
+++ b/bin/ssh-remove-known-host
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Helper script to remove entries for ~/.ssh/known hosts
+#
+# I can never remember the command to remove a host, and since the format update, you can't just edit `~/.ssh/known_hosts` and search for the IP/hostname.
+# Not sure why they switched to a new format that's more pain in the ass.
+#
+# Copyright 2023, Joe Block <jpb@unixorn.net>
+# License: BSD
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  # shellcheck disable=SC2086
+  if [[ "$(echo $DEBUG | tr '[:upper:]' '[:lower:]')" == "verbose" ]]; then
+    set -x
+  fi
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function echo-stderr() {
+  echo "$@" 1>&2  ## Send message to stderr.
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+function check-dependencies() {
+  debug "Checking dependencies..."
+  # shellcheck disable=SC2041
+  for p in 'ssh-keygen'
+  do
+    if ! has $p; then
+      fail "Can't find $p in your $PATH"
+    else
+      debug "- Found $p"
+    fi
+  done
+}
+
+function my-name() {
+  basename "$0"
+}
+
+function usage() {
+  echo "Usage: $(my-name) dns_or_ip"
+  echo "Deletes a host or IP from your known_hosts file"
+}
+
+check-dependencies
+
+exec ssh-keygen -f ~/.ssh/known_hosts -R "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Description

I can never remember the command to remove a host, and since the format update, you can't just edit `~/.ssh/known_hosts` and search for the IP/hostname.

Not sure why they switched to a new format that's more pain in the ass.

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated Readme.md to give credit to the script author
- [x] I have updated Readme.md to describe what the script does
- [x] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
