### PR TITLE
fix: set GREP_COLORS correctly for GNU grep >= 3.8

### DIFF
--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -69,6 +69,12 @@ function historygram() {
     awk '!max{max=$1;}{r="";i=s=60*$1/max;while(i-->0)r=r"#";printf "%15s %5d %s %s",$2,$1,r,"\n";}'
 }
 
+function version_greater_equal()
+{
+    printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
+}
+
+
 # IP address fiddling
 alias external_ip='curl -s icanhazip.com'
 alias my_ips="ifconfig -a | perl -nle'/(\d+\.\d+\.\d+\.\d+)/ && print $1'"
@@ -129,7 +135,11 @@ alias ':q'="exit"
 alias ..='cd ..'
 alias gerp='grep'
 alias grep-i='grep -i'
-alias grep='GREP_COLOR="1;37;41" LANG=C grep --color=auto'
+if version_greater_equal $(grep -V | head -1 | grep GNU | cut -d" " -f4 ) 3.8; then
+  alias grep='GREP_COLORS="mt=1;37;41" LANG=C grep --color=auto'
+else
+  alias grep='GREP_COLOR="1;37;41" LANG=C grep --color=auto'
+fi
 alias grepi='grep -i'
 alias maek='make'
 alias mkdir-p='mkdir -p'


### PR DESCRIPTION
fixes #95

<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context

the GREP_COLOR setting is deprecated in GNU grep >= 3.8 and spits deprecation errors

# Description

* Added a function to compare two strings that contain versions
* used it to compare against 3.8 (and GNU)
* sets GREP_COLOR(S) accordingly

# How Has This Been Tested?

works fine here locally

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Adding or updating utility script(s)
- [x] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
