### PR TITLE
Minor tweaks to newscript

### DIFF
--- a/bin/newscript
+++ b/bin/newscript
@@ -47,7 +47,7 @@ def generate_bash_script(name:)
 # This base script is MIT licensed so you can base your
 # own work on it.
 #
-# Script skeleton
+# #{name} script skeleton
 #
 # Copyright #{copyright_year}, Your Name <yourname@yourdomain.com>
 
@@ -59,18 +59,18 @@ if [[ -n "$DEBUG" ]]; then
   fi
 fi
 
+function echo-stderr() {
+  printf '%s\\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+}
+
 function debug() {
   if [[ -n "$DEBUG" ]]; then
     echo-stderr "$@"
-  fi
-}
-
-function echo-stderr() {
-  echo "$@" 1>&2  ## Send message to stderr.
-}
-
+    fi
+  }
+  
 function fail() {
-  printf '%s\\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  echo-stderr "$1"
   exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
 }
 
@@ -121,6 +121,7 @@ function get-settings() {
 }
 
 function only-run-on() {
+  # shellcheck disable=SC2086
   if [[ "$(uname -s | tr '[:upper:]' '[:lower:]')" != "$(echo $1 | tr '[:upper:]' '[:lower:]')" ]]; then
     fail "This script only runs on $1, this machine is running $(uname -s)"
   else
@@ -179,6 +180,11 @@ function path-exists() {
   fail "$1 is not a directory or file"
 }
 
+# If you need to restrict to a specific os, use
+# only-run-on Darwin
+# or
+# only-run-on Linux
+
 # Placeholders for your script's real dependencies
 check-dependencies bash cat
 
@@ -194,7 +200,7 @@ def generate_python_script(name:)
 # This base script is MIT licensed so you can base your
 # own work on it.
 #
-# Script skeleton
+# ${name} script skeleton
 #
 # Copyright #{copyright_year}, Your Name <yourname@yourdomain.com>
 

--- a/bin/newscript
+++ b/bin/newscript
@@ -68,7 +68,7 @@ function debug() {
     echo-stderr "$@"
     fi
   }
-  
+
 function fail() {
   echo-stderr "$1"
   exit "${2-1}"  ## Return a code specified by $2 or 1 by default.


### PR DESCRIPTION
# Motivation and Context

Bash templates generated by `newscript` had places that `shellcheck` complained about.
I don't need a complaint that `$foo` isn't in `"` when it's something like `aa="$(foo bar $baz)"

# Description

- Add shellcheck disables for some functions
- Improve inline examples

# How Has This Been Tested?

Been using it on my personal laptop and am finally getting around to merging the changes.

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
