### PR TITLE
Update newscript, add `port-listened-by`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 | `pjson` | [https://coderwall.com/](https://coderwall.com/p/hwu5uq?i=9&p=1&q=sort%3Ascore+desc&t%5B%5D=zsh) | Prettify json files |
 | `plot` | katef's [gist](https://gist.github.com/katef/fb4cb6d47decd8052bd0e8d88c03a102) | Draw a graph in the terminal |
 | `port-listeners-ipv{4,6}` | jpb@unixorn.net | Show what programs are listening to a given port |
+| `port-listened-by}` | jpb@unixorn.net | Show what programs are listening to a given port |
 | `pydoc` | Hangops Slack | Look something up on [docs.python.org](https://docs.python.org) and opens it in your default browser |
 | `random-password` | jpb@unixorn.net | Generate a random password. If no argument, assume 32 character length |
 | `randsleep` | jpb@unixorn.net | Sleep a random number of seconds |

--- a/bin/newscript
+++ b/bin/newscript
@@ -60,14 +60,14 @@ if [[ -n "$DEBUG" ]]; then
 fi
 
 function echo-stderr() {
-  printf '%s\\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
 }
 
 function debug() {
   if [[ -n "$DEBUG" ]]; then
-    echo-stderr "$@"
-    fi
-  }
+      echo-stderr "$@"
+  fi
+}
 
 function fail() {
   echo-stderr "$1"
@@ -187,6 +187,40 @@ function path-exists() {
 
 # Placeholders for your script's real dependencies
 check-dependencies bash cat
+
+# parse arguments
+A_BOOL_SETTING='false'
+
+while :
+do
+  if [[ $# == 0 ]]; then
+    break
+  fi
+  case "$1" in
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    --set-a-bool-to-true)
+      A_BOOL_SETTING='true'
+      shift
+      ;;
+    --set-a-value)
+      shift
+      A_VALUE="$1"
+      shift
+      ;;
+    -- )
+      shift;
+      break
+      ;;
+    *)
+      echo-stderr "Unexpected option: $1"
+      usage
+      fail "Invalid CLI argument: '$1'"
+      ;;
+  esac
+done
 
 END_BASH_SCRIPT
   write_script(name: name, source: rawScript)

--- a/bin/port-listened-by
+++ b/bin/port-listened-by
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# This base script is MIT licensed so you can base your
+# own work on it.
+#
+# Find what is listening on a port
+#
+# Copyright 2025, Joe Block <jpb@unixorn.net>
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  # shellcheck disable=SC2086
+  if [[ "$(echo $DEBUG | tr '[:upper:]' '[:lower:]')" == "verbose" ]]; then
+    set -x
+  fi
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function echo-stderr() {
+  echo "$@" 1>&2  ## Send message to stderr.
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+function only-run-on() {
+  # shellcheck disable=SC2086
+  if [[ "$(uname -s | tr '[:upper:]' '[:lower:]')" != "$(echo $1 | tr '[:upper:]' '[:lower:]')" ]]; then
+    fail "This script only runs on $1, this machine is running $(uname -s)"
+  else
+    debug "OS ($(uname -s)) is valid..."
+  fi
+}
+
+function check-dependency() {
+  if ! (builtin command -V "$1" >/dev/null 2>&1); then
+    fail "missing dependency: can't find $1 in your PATH"
+  fi
+}
+
+function check-dependencies() {
+  debug "Checking dependencies..."
+  # shellcheck disable=SC2041
+  # Placeholders for whatever programs you really need
+  for dep in "$@"
+  do
+    if ! has "$dep"; then
+      fail "Can't find $dep in your $PATH"
+    else
+      debug "- Found $dep"
+    fi
+  done
+}
+
+function my-name() {
+  basename "$0"
+}
+
+function usage() {
+  echo "Usage: $(my-name) PORT"
+  echo
+  echo "Uses lsof to see what is listening on PORT"
+}
+
+check-dependencies awk lsof uniq
+
+lsof -i -P -n | grep "$@" | awk '/LISTEN/  {print  $9}' | uniq


### PR DESCRIPTION
# Description

- Add an arg parser to newscript-created bash scripts
- Add `port-listened-by` script

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Adding or updating utility script(s)
- [ ] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [x] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [x] I have run `shellcheck` on all shell scripts touched in my branch.
- [x] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [x] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
