### PR TITLE
Fix watch function to show seconds in output

### DIFF
--- a/jpb.plugin.zsh
+++ b/jpb.plugin.zsh
@@ -219,7 +219,7 @@ sha512() {
 }
 
 # from commandlinefu.com
-watch() { t=$1; shift; while test :; do clear; date=$(date); echo -e "Every $ts: $@ \t\t\t\t $date"; $@; sleep $t; done }
+watch() { t=$1; shift; while test :; do clear; date=$(date); echo -e "Every ${t}s: $@ \t\t\t\t $date"; $@; sleep $t; done }
 
 calc() {
   awk "BEGIN{ print $* }" ;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The 'watch' funtion's delay formatting in the status bar is broken.

Running 'watch 1 ls' currently prints this in the status bar:

Every : ls

Formatting ${t}s instead fixes that to the intended behaviour:

Every 1s: ls

# Description
<!--- Describe your changes in detail -->

Fix seconds formating in watch function

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Just set the function in my interactive shell

# Rights

- [X] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Adding or updating utility script(s)
- [X] Add/update function in `jpb.plugin.zsh`
- [ ] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts

- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable.
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
